### PR TITLE
Update github rule regex to skip common githead tag

### DIFF
--- a/Tools/s3-secrets-scanner/rules.json
+++ b/Tools/s3-secrets-scanner/rules.json
@@ -102,7 +102,7 @@
     },
     {
       "Reason": "Github",
-      "Rule": "github.*['|\"][0-9a-zA-Z]{35,40}['|\"]",
+      "Rule": "github.*(?<!['|\"]gitHead['|\"]:)['|\"][0-9a-zA-Z]{35,40}['|\"],
       "Noise": 3
     },
     {


### PR DESCRIPTION
Squash recurring false positives due to githead hash being interpretted as github token.